### PR TITLE
Rename submit of an MR to merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ account the MR dependency chain.
 
 ```console
 $ git review -m
-Submitting merge requests:
+Merging merge requests:
 * https://gitlab.example.com/myproject/-/merge_requests/110 tests: Add commit a.
     [mergeable]: True
 * https://gitlab.example.com/myproject/-/merge_requests/111 tests: Add commit b.

--- a/gerritlab/main.py
+++ b/gerritlab/main.py
@@ -9,10 +9,10 @@ from gerritlab.utils import Bcolors, msg_with_color, print_with_color, warn
 from gerritlab.pipeline import PipelineStatus
 
 
-def submit_merge_requests(remote, local_branch):
-    """Submits merge requests."""
+def merge_merge_requests(remote, local_branch):
+    """Merges merge requests."""
 
-    print("\nSubmitting merge requests:")
+    print("\nMerging merge requests:")
 
     # Get MRs created off of the given branch.
     mrs = merge_request.get_all_merge_requests(remote, local_branch)
@@ -43,13 +43,13 @@ def submit_merge_requests(remote, local_branch):
             "mergeable.".format(global_vars.global_target_branch))
         return
 
-    # We must submit MRs from the oldest. And before submitting an MR, we
+    # We must merge MRs from the oldest. And before merging an MR, we
     # must change its target_branch to the main branch.
     for mr in mergeables:
         mr.update(target_branch=global_vars.global_target_branch)
         #FIXME: Poll the merge req status and waiting until
         # merge_status is no longer "checking".
-        mr.submit()
+        mr.merge()
 
     print_with_color("\nSUCCESS\n", Bcolors.OKGREEN)
     print("New Merged MRs:")
@@ -254,9 +254,9 @@ def main():
                 "HEAD is detached. Are you in the process of a rebase?")
         local_branch = repo.active_branch.name
 
-    # Submit the MRs if they become mergeable.
+    # Merge the MRs if they become mergeable.
     if args.merge:
-        submit_merge_requests(remote, local_branch)
+        merge_merge_requests(remote, local_branch)
         sys.exit(0)
 
     create_merge_requests(repo, remote, local_branch)

--- a/gerritlab/merge_request.py
+++ b/gerritlab/merge_request.py
@@ -85,9 +85,9 @@ class MergeRequest:
         self._iid = data["iid"]
         self._web_url = data["web_url"]
 
-    def submit(self):
+    def merge(self):
         if self._iid is None:
-            raise ValueError("Must set iid before submittng an MR!")
+            raise ValueError("Must set iid before merging an MR!")
         url = "{}/{}/merge".format(global_vars.mr_url, self._iid)
         while True:
             r = requests.put(url, headers=global_vars.headers)


### PR DESCRIPTION
"Submit" was confusing to me, and does not seem to be nomenclature used
by Gitlab itself. Initially i assumed "submit" meant creating an MR.

Change-Id: Ia85b07c27ee0082e39ffce531dfa8b57eb85c073